### PR TITLE
feat(types): expose the prop types

### DIFF
--- a/src/react-sortable-tree.tsx
+++ b/src/react-sortable-tree.tsx
@@ -787,7 +787,7 @@ type OnDragStateChangedParams = {
   draggedNode: any
 }
 
-type ReactSortableTreeProps = {
+export type ReactSortableTreeProps = {
   dragDropManager?: {
     getMonitor: () => unknown
   }


### PR DESCRIPTION
This will expose the component type definitions.

```ts
// typescript
import type { ReactSortableTreeProps } from "@nosferatu500/react-sortable-tree/react-sortable-tree"

// jsdoc
/**
 * @typedef {import("@nosferatu500/react-sortable-tree/react-sortable-tree").ReactSortableTreeProps} ReactSortableTreeProps
 */
```