### PR TITLE
Fix getNodeDataAtTreeIndexOrNextIndex for when node is undefined

### DIFF
--- a/src/utils/tree-data-utils.ts
+++ b/src/utils/tree-data-utils.ts
@@ -61,7 +61,7 @@ const getNodeDataAtTreeIndexOrNextIndex = ({
   }
 
   // Add one and continue for nodes with no children or hidden children
-  if (!node.children || (ignoreCollapsed && node.expanded !== true)) {
+  if (!node?.children || (ignoreCollapsed && node?.expanded !== true)) {
     return { nextIndex: currentIndex + 1 }
   }
 


### PR DESCRIPTION
This is a minor fix for when nodes are undefined - as is the case sometimes when using lazy loading.