### PR TITLE
Use esm source as module

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "4.1.4",
   "description": "Drag-and-drop sortable component for nested data and hierarchies",
   "main": "./index.js",
+  "module": "./esm/index.js",
   "types": "./index.d.ts",
   "exports": {
     "./package.json": "./package.json",


### PR DESCRIPTION
We found that our site didn't work on older browsers, and found out the reason is this package used cjs source in webpack.

Add `module` field to use esm source will solve the issue.