### PR TITLE
fix: fix the scroll on drag issue

### DIFF
--- a/src/react-sortable-tree.tsx
+++ b/src/react-sortable-tree.tsx
@@ -211,7 +211,13 @@ class ReactSortableTree extends Component {
     this.scrollZoneVirtualList = (createScrollingComponent || withScrolling)(
       React.forwardRef((props, ref) => {
         const { dragDropManager, rowHeight, ...otherProps } = props
-        return <Virtuoso ref={this.listRef} {...otherProps} />
+        return (
+          <Virtuoso
+            ref={this.listRef}
+            scrollerRef={(scrollContainer) => (ref.current = scrollContainer)}
+            {...otherProps}
+          />
+        )
       })
     )
     this.vStrength = createVerticalStrength(slideRegionSize)


### PR DESCRIPTION
The scroll on drag operation based on `@nosferatu500/react-dnd-scrollzone` has no effect. Because the `ref` was not connected to the scroll parent of `react-virtuoso`.

Before:
![Nov-10-2022 12-04-29](https://user-images.githubusercontent.com/33218310/200998999-9327b557-2d8f-482a-9f7b-6810715a5d53.gif)

After:
![Nov-10-2022 12-05-56](https://user-images.githubusercontent.com/33218310/200999024-b59a1859-4370-43e1-860d-d5b9f3d6b8cb.gif)
