### PR TITLE
Fix getTreeFromFlatData regression with null rootKey

### DIFF
--- a/src/utils/tree-data-utils.ts
+++ b/src/utils/tree-data-utils.ts
@@ -991,7 +991,7 @@ export const getTreeFromFlatData = <T extends Record<string, unknown>>({
     getParentKey(child)
   )
 
-  if (rootKey === null || !childrenToParents[rootKey]) {
+  if (!(String(rootKey) in childrenToParents)) {
     return []
   }
 


### PR DESCRIPTION
this fix brings the storybook up to 4..4.0 behaviour

https://nosferatu500.github.io/react-sortable-tree/?path=/story/basics--tree-data-import-export

https://frontend-collective.github.io/react-sortable-tree/?path=/story/basics--treedata-import-export